### PR TITLE
freeView에서 댓글 작업 전까지

### DIFF
--- a/workspace/campfire/src/main/java/com/campfire/controller/FreeBoardReplyController.java
+++ b/workspace/campfire/src/main/java/com/campfire/controller/FreeBoardReplyController.java
@@ -1,19 +1,13 @@
 package com.campfire.controller;
 
-import java.util.List;
-
-import javax.swing.text.html.FormSubmitEvent.MethodType;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext.MethodMode;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.campfire.domain.Criteria;

--- a/workspace/campfire/src/main/webapp/WEB-INF/views/free/freeList.jsp
+++ b/workspace/campfire/src/main/webapp/WEB-INF/views/free/freeList.jsp
@@ -89,18 +89,18 @@
                                        </tr>
                                     </thead>
                                     <tbody>
-                                       <%-- <c:forEach var="board" items="${list}">
+                                       <c:forEach var="board" items="${list}">
                                           <tr class="tBody">
                                              <td class="bno">${board.bno}</td>
-                                             <td class="title"><a href="/board/get${pageMaker.cri.getListLink()}&bno=${board.bno}">${board.title}</a>
+                                             <td class="title"><a href="/free/freeView${pageMaker.cri.getListLink()}&bno=${board.bno}">${board.title}</a>
                                              	<i style="font-size: 35px;" class="far fa-heart"></i><span style="font-size: 0.5rem;">[${board.replyCnt}]</span><i className="material-icons">fiber_new</i><i class="fas fa-heart"></i><i class="material-icons">fiber_new</i>
                                              </td>
                                              <td class="writer">${board.writer}</td>
                                              <td class="regDate">${board.regDate}</td>
                                              <td class="updateDate">${board.updateDate}</td>
                                           </tr>
-                                       </c:forEach> --%>
-                                          <tr class="tBody">
+                                       </c:forEach>
+                                          <%-- <tr class="tBody">
                                              <td class="bno">1234567</td>
                                              <td class="title"><a href="#" style="color: black !important;">자유게시판 테스트용 제목입니다.</a>&nbsp;<span style="font-weight: bold; color: #ff2f3b;">[3]</span>
                                              	<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M7.25 12.5L4.75 9H3.5v6h1.25v-3.5L7.3 15h1.2V9H7.25zM9.5 15h4v-1.25H11v-1.11h2.5v-1.26H11v-1.12h2.5V9h-4zm9.75-6v4.5h-1.12V9.99h-1.25v3.52h-1.13V9H14.5v5c0 .55.45 1 1 1h4c.55 0 1-.45 1-1V9h-1.25z"/></svg>
@@ -108,7 +108,7 @@
                                              <td class="writer">모닥불 테스터</td>
                                              <td class="regDate">2021.06.03</td>
                                              <td class="readCnt">27</td>
-                                          </tr>
+                                          </tr> --%>
                                     </tbody>
                                     <tfoot>
                                     </tfoot>

--- a/workspace/campfire/src/main/webapp/WEB-INF/views/free/freeView.jsp
+++ b/workspace/campfire/src/main/webapp/WEB-INF/views/free/freeView.jsp
@@ -10,6 +10,11 @@
 		<meta name="keywords" content="" />
 		<link rel="stylesheet" href="/resources/assets/css/main.css" />
 		<link rel="shortcut icon" type="image/x-icon" href="/resources/images/icon/title-icon.png">
+		<style>
+			.content img {
+				width: 100% !important;
+			}
+		</style>
 	</head>
 	<body class="is-preload">
 <%@include file="../includes/header.jsp" %>
@@ -18,33 +23,32 @@
 		<section class="main special" style="margin-top: 30px;">
 			<div class="inner banner">
 				<header class="major">
-					<span class="category">캠핑 리뷰</span>
+					<span class="category">자유게시판</span>
 				</header>
 			</div>
 			<div class="row" style="display:block;">
-				<div class="col-6 col-10-medium col-11-small" style="margin: 0 auto;"><h2 style="font-weight: bold;">리뷰 상세보기</h2></div>
+				<div class="col-6 col-10-medium col-11-small" style="margin: 0 auto;"><h2 style="font-weight: bold;">제목 : ${board.title}</h2></div>
 				<div class="col-6 col-10-medium col-11-small" style="margin: 0 auto;">
 					<div class="header">
 						<h3 style="font-weight: bold; text-align: left; margin: 0 0;">
-							테스트 제목입니다.
+							No.${board.bno}
 						</h3>
 						<div style="position: absolute;">
-							<span>작성자 : ㅇㅇㅇ</span>
+							<span>작성자 : ${board.writer}</span>
 						</div>
 						<div style="text-align: right;">
 							<span>조회수 : ㅇㅇㅇ</span>
 						</div>
 					</div>
-					<div style="margin-bottom: 10px;">
-						<textarea rows="12" cols="">테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.
-						테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.
-						테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.</textarea>
+					<div style="margin-bottom: 10px; width: 100%;" class="content">
+						${board.content}
+						<!-- <textarea rows="" cols=""></textarea> -->
 					</div>
 				</div>
 				<div class="col-6 col-10-medium col-11-small" style="margin: 0 auto 10px auto;">
 					<div class="row">
 						<div class="col-3" style="text-align:left; text-decoration: none;">
-							<a href="#" id="heartIcon" style="font-size:18px;text-decoration: none;"><i style="font-size: 35px;" class="far fa-heart"></i>123개</a>
+							<a href="#" id="heartIcon" style="font-size:18px;text-decoration: none;"><i style="font-size: 35px;" class="far fa-heart"></i>${board.likeCnt}</a>
 						</div>
 						<div class="col-9" style="text-align: right;">
 							<a href="#" style="font-size: 21px; text-decoration: none;">테드한의 캠핑장 바로가기</a>
@@ -74,7 +78,7 @@
 					<div>
 						<h3 style="font-weight: bold; text-align: left; margin: 0 0;">댓글</h3>
 					</div>
-					<ul class="alt">
+					<ul class="alt replies">
 						<li>
 							<div style="position: absolute;">
 								<h4 style="margin: 0; text-align: left;">작성자: 고희광</h4>
@@ -98,19 +102,108 @@
 							</div>
 						</li>
 					</ul>
+					<div class="paging" style="text-align: center;">
+									
+					</div>
 				</div>
 			</div>
 		</section>
 </div>
 <jsp:include page="../includes/footer.jsp"/>
+<script src="/resources/assets/js/reply.js"></script>
 	</body>
 	<script>
 		$(document).ready(function () {
+			var pageNum = 1;
+			var bno = "${board.bno}";
+			
 			$("#heartIcon").on("click", function(e){
 				e.preventDefault();
 				$(this).find(".fa-heart").toggleClass("far");
 				$(this).find(".fa-heart").toggleClass("fas");
 			});
+			
+			
+			function showReplyPage(replyCnt){
+				var str = "";
+				var endNum = Math.ceil(pageNum / 10.0) * 10
+				var startNum = endNum - 9;
+				var realEnd = Math.ceil(replyCnt / 10.0)
+				var divTag = $(".paging");   			
+				
+				if(endNum > realEnd){
+					endNum = realEnd;
+				}
+				
+				var prev = startNum != 1;
+				var next = endNum * 10 < replyCnt;
+				
+				if(matchMedia("screen and (max-width:918px)").matches){
+					//918px보다 작을 때
+					if(pageNum > 1){
+						str += "<a class='changePage' href='" + (pageNum - 1) + "'><code>&lt;</code></a>";
+					}
+					str += "<code>" + pageNum + "</code>";
+					if(pageNum < realEnd){
+						str += "<a class='changePage' href='" + (pageNum + 1) + "'><code>&gt;</code></a>";
+					}
+				}else{
+					//918px 이상일 때
+					if(prev){
+						str += "<a class='changePage' href='" + (startNum - 1) + "'><code>&lt;</code></a>";
+					}
+					for(let i=startNum; i<=endNum; i++){
+						if(i == pageNum){
+							str += "<code>" + i + "</code>";
+							continue;
+						}
+						str += "<a class='changePage' href='" + i + "'><code>" + i + "</code></a>";
+					}
+					if(next){
+						str += "<a class='changePage' href='" + (endNum + 1) + "'><code>&gt;</code></a>";
+					}
+				}
+				
+				divTag.html(str);
+			}
+			
+			function showList(page){
+				console.log
+				var replyUL = $(".replies");
+				
+				replyService.getList({bno:bno, page:page||1},
+						function(replyCnt, list){
+							var str = "";
+							if(list == null || list.length == 0){
+								//등록된 댓글이 없습니다.
+								if(pageNum > 1) {
+									pageNum -= 1;
+									showList(pageNum);
+								}
+								replyUL.html("등록된 댓글이 없습니다.");
+								return;
+							}
+							for(let i=0, len=list.length; i<len; i++){
+								str += "<li data-rno='" + list[i].rno + "'>";
+								str += "<strong>" + list[i].replyer + "</strong>";
+								str += "<p class='reply" + list[i].rno + "'>" + list[i].reply + "</p>";
+								str += "<div style='text-align:right;'>";
+								str += "<strong>" + replyService.displayTime(list[i].replyDate);
+								if(list[i].replyDate != list[i].updateDate){
+									str += "<br>수정된 날짜 " +replyService.displayTime(list[i].updateDate);
+								}
+								str += "</strong><br><a class='modify' href='" + list[i].rno + "'>수정</a>";
+								str += "<a class='finish' href='" + list[i].rno + "' style='display:none;'>수정완료</a>";
+								str += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
+								str += "<a class='remove' href='" + list[i].rno + "'>삭제</a>";
+								str += "</div><div class='line'></div></li>";
+							}
+							replyUL.html(str);
+							showReplyPage(replyCnt);
+				});
+			}
+
+			showList(pageNum);
 		});
 	</script>
 </html>

--- a/workspace/campfire/src/main/webapp/resources/assets/js/reply.js
+++ b/workspace/campfire/src/main/webapp/resources/assets/js/reply.js
@@ -1,0 +1,18 @@
+/**
+ * 
+ */
+
+var replyService = (function(){
+	function getList(reply, callback, error){
+		$.getJSON("/freeReplies/freeReplyList/"+reply.bno+"/"+reply.page+".json", function(data){
+			if(callback){
+				console.log("data.replyCnt : "+data.replyCnt);
+				console.log("data.list : "+data.list);
+				callback(data.replyCnt, data.list);}
+		}).fail(function(xhr, status, err){
+			if(error){error(err);}
+		});
+	}
+	
+	return {getList: getList}
+})();

--- a/workspace/campfire/src/test/java/com/campfire/mapper/ReplyMapperTests.java
+++ b/workspace/campfire/src/test/java/com/campfire/mapper/ReplyMapperTests.java
@@ -27,8 +27,8 @@ public class ReplyMapperTests {
 //	@Test
 //	public void testInsert() {
 //		FreeBoardReplyVO vo = new FreeBoardReplyVO();
-//		vo.setBno(30L);
-//		vo.setReply("히위고");
+//		vo.setBno(89L);
+//		vo.setReply("댓글테스트용");
 //		vo.setReplyer("test1");
 //		mapper.insert(vo);
 //	}
@@ -41,7 +41,7 @@ public class ReplyMapperTests {
 	
 //	@Test
 //	public void testTotal() {
-//		log.info(mapper.getTotal(30L));
+//		log.info(mapper.getTotal(89L));
 //	}
 	
 //	@Test

--- a/workspace/campfire/src/test/java/com/campfire/service/ReplyServiceTests.java
+++ b/workspace/campfire/src/test/java/com/campfire/service/ReplyServiceTests.java
@@ -27,7 +27,7 @@ public class ReplyServiceTests {
 	@Test
 	public void testList() {
 		Criteria cri = new Criteria(1, 12);
-		log.info(service.getList(cri, 30L));
+		log.info(service.getList(cri, 89L));
 	}
 	
 //	@Test


### PR DESCRIPTION
freeView에서 댓글 구현 전까지 작업 완료.
썸머노트를 이용해 글을 등록할 때
이미지를 첨부할 경우 그 이미지는 사이즈에 맞춰 <img width:>형식으로 추가되어
게시글 테이블의 content에 들어가는데
불러오는 과정에서 <textarea>는 태그를 적용하지 않고 그대로 보여주기 때문에
<textarea>를 제거하고 <div>내에서 사용하되 이미지의 크기를 width 100%로 수정하였음.